### PR TITLE
Update jotform.py

### DIFF
--- a/jotform.py
+++ b/jotform.py
@@ -12,7 +12,7 @@ import urllib.request, urllib.parse, urllib.error
 import json
 
 class JotformAPIClient:
-    DEFAULT_BASE_URL = 'https://sambasafety.jotform.com/API'
+    DEFAULT_BASE_URL = 'https://sambasafety.jotform.com/API/'
     EU_BASE_URL = 'https://eu-api.jotform.com/'
 
     __apiVersion = 'v1'


### PR DESCRIPTION
I believe you're missing a trailing slash, so endpoints would become /APIform rather than /API/form for example